### PR TITLE
[feat] 관리자 페이지 거래 내역 관리 메뉴 추가

### DIFF
--- a/src/app/admin/trades/page.tsx
+++ b/src/app/admin/trades/page.tsx
@@ -122,28 +122,6 @@ export default function AdminTradesPage() {
     refetch(); // 거래 목록 새로고침
   };
 
-  // 카테고리를 한글로 변환하는 함수
-const getCategoryLabel = (category: string): string => {
-  switch (category) {
-    case 'PRODUCT':
-      return '물건발명';
-    case 'METHOD':
-      return '방법발명';
-    case 'USE':
-      return '용도발명';
-    case 'DESIGN':
-      return '디자인권';
-    case 'TRADEMARK':
-      return '상표권';
-    case 'COPYRIGHT':
-      return '저작권';
-    case 'ETC':
-      return '기타';
-    default:
-      return category;
-  }
-};
-
   // 필터링된 거래 목록
   const filteredTrades = tradesWithPostInfo.filter(trade => {
     const matchesSearch = trade.id.toString().includes(searchTerm) ||
@@ -286,7 +264,7 @@ const getCategoryLabel = (category: string): string => {
                   {trades.length === 0 ? '등록된 거래가 없습니다.' : '검색 결과가 없습니다.'}
                 </p>
                 <p className="text-sm text-gray-500 mt-2">
-                  '다른 검색어나 필터를 시도해보세요.'
+                  다른 검색어나 필터를 시도해보세요.
                 </p>
               </div>
             ) : (

--- a/src/app/admin/trades/page.tsx
+++ b/src/app/admin/trades/page.tsx
@@ -1,27 +1,128 @@
 'use client';
 
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import { adminAPI } from "@/utils/apiClient";
 import AdminNavigation from "@/components/AdminNavigation";
 import AdminLoadingSpinner from "@/components/AdminLoadingSpinner";
 import { useAdminTable } from "@/hooks/useAdminTable";
-import PatentDetailModal from "@/components/admin/PatentDetailModal";
+import TradeDetailModal from "@/components/admin/TradeDetailModal";
 
-interface Patent {
+interface Trade {
   id: number;
-  title: string;
-  description: string;
-  category: string;
+  postId: number;
+  sellerId: number;
+  buyerId: number;
   price: number;
   status: string;
   createdAt: string;
-  modifiedAt?: string;
-  favoriteCnt: number;
-  authorId: number; 
-  authorName?: string; 
 }
 
-// 카테고리를 한글로 변환하는 함수
+interface TradeWithPostInfo extends Trade {
+  postTitle?: string;
+  postCategory?: string;
+}
+
+// 거래 상태를 한글로 변환하는 함수
+const getStatusLabel = (status: string): string => {
+  switch (status) {
+    case 'REQUEST':
+      return '거래 요청';
+    case 'ACCEPT':
+      return '거래 수락';
+    case 'CANCELED':
+      return '거래 취소';
+    case 'COMPLETED':
+      return '거래 완료';
+    default:
+      return status;
+  }
+};
+
+// 거래 상태에 따른 색상 클래스
+const getStatusColor = (status: string): string => {
+  switch (status) {
+    case 'REQUEST':
+      return 'bg-yellow-100 text-yellow-800';
+    case 'ACCEPT':
+      return 'bg-blue-100 text-blue-800';
+    case 'CANCELED':
+      return 'bg-red-100 text-red-800';
+    case 'COMPLETED':
+      return 'bg-green-100 text-green-800';
+    default:
+      return 'bg-gray-100 text-gray-800';
+  }
+};
+
+export default function AdminTradesPage() {
+  const [selectedTradeId, setSelectedTradeId] = useState<number | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [statusFilter, setStatusFilter] = useState<string>('ALL');
+  const [sortBy, setSortBy] = useState<string>('createdAt');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+  const [tradesWithPostInfo, setTradesWithPostInfo] = useState<TradeWithPostInfo[]>([]);
+
+  // fetchData 함수를 useCallback으로 감싸서 안정적인 참조 제공
+  const fetchTrades = useCallback(async () => {
+    const response = await adminAPI.getAllTrades();
+    // 백엔드 응답 구조에 맞게 데이터 추출
+    // 백엔드 응답: { resultCode: "200-1", msg: "...", data: { content: [...], ... } }
+    return response?.data?.content || [];
+  }, []);
+
+  const { user, isAuthenticated, loading, data: trades, isLoading, error, refetch } = useAdminTable<Trade>(fetchTrades);
+
+  // 거래 목록이 변경될 때마다 게시글 정보를 가져오기
+  useEffect(() => {
+    if (trades.length > 0) {
+      fetchPostInfoForTrades(trades);
+    }
+  }, [trades]);
+
+  // 각 거래에 대해 게시글 정보를 가져오는 함수
+  const fetchPostInfoForTrades = async (trades: Trade[]) => {
+    const tradesWithInfo: TradeWithPostInfo[] = [];
+    
+    for (const trade of trades) {
+      try {
+        // 거래 상세 정보를 가져와서 게시글 제목과 카테고리 추출
+        const detailResponse = await adminAPI.getTradeDetail(trade.id);
+        const tradeDetail = detailResponse?.data;
+        
+        tradesWithInfo.push({
+          ...trade,
+          postTitle: tradeDetail?.postTitle || '제목 없음',
+          postCategory: tradeDetail?.postCategory || '카테고리 없음'
+        });
+      } catch (error) {
+        console.error(`거래 ${trade.id} 상세 정보 조회 실패:`, error);
+        tradesWithInfo.push({
+          ...trade,
+          postTitle: '제목 없음',
+          postCategory: '카테고리 없음'
+        });
+      }
+    }
+    
+    setTradesWithPostInfo(tradesWithInfo);
+  };
+
+  const handleTradeClick = (tradeId: number) => {
+    setSelectedTradeId(tradeId);
+    setIsModalOpen(true);
+  };
+
+  const handleModalClose = () => {
+    setIsModalOpen(false);
+    setSelectedTradeId(null);
+  };
+
+  const handleTradeUpdated = () => {
+    refetch(); // 거래 목록 새로고침
+  };
+
+  // 카테고리를 한글로 변환하는 함수
 const getCategoryLabel = (category: string): string => {
   switch (category) {
     case 'PRODUCT':
@@ -43,61 +144,18 @@ const getCategoryLabel = (category: string): string => {
   }
 };
 
-// 상태를 한글로 변환하는 함수
-const getStatusLabel = (status: string): string => {
-  switch (status) {
-    case 'SALE':
-      return '판매중';
-    case 'SOLD_OUT':
-      return '판매완료';
-    case 'SUSPENDED':
-      return '판매중단';
-    default:
-      return status;
-  }
-};
-
-export default function AdminPatentsPage() {
-  const [selectedPatentId, setSelectedPatentId] = useState<number | null>(null);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [categoryFilter, setCategoryFilter] = useState<string>('ALL');
-  const [sortBy, setSortBy] = useState<string>('createdAt');
-  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
-
-  // fetchData 함수를 useCallback으로 감싸서 안정적인 참조 제공
-  const fetchPatents = useCallback(async () => {
-    const response = await adminAPI.getAllPatents();
-    // 백엔드 응답 구조에 맞게 데이터 추출
-    // 백엔드 응답: { resultCode: "200-1", msg: "...", data: { content: [...], ... } }
-    return response?.data?.content || [];
-  }, []);
-
-  const { user, isAuthenticated, loading, data: patents, isLoading, error, refetch } = useAdminTable<Patent>(fetchPatents);
-
-  const handlePatentClick = (patentId: number) => {
-    setSelectedPatentId(patentId);
-    setIsModalOpen(true);
-  };
-
-  const handleModalClose = () => {
-    setIsModalOpen(false);
-    setSelectedPatentId(null);
-  };
-
-  const handlePatentUpdated = () => {
-    refetch(); // 특허 목록 새로고침
-  };
-
-  // 필터링된 특허 목록
-  const filteredPatents = patents.filter(patent => {
-    const matchesSearch = (patent.title?.toLowerCase() || '').includes(searchTerm.toLowerCase());
-    const matchesCategory = categoryFilter === 'ALL' || patent.category === categoryFilter;
-    return matchesSearch && matchesCategory;
+  // 필터링된 거래 목록
+  const filteredTrades = tradesWithPostInfo.filter(trade => {
+    const matchesSearch = trade.id.toString().includes(searchTerm) ||
+                         (trade.postTitle && trade.postTitle.includes(searchTerm)) ||
+                         (trade.postCategory && trade.postCategory.includes(searchTerm)) ||
+                         trade.price.toString().includes(searchTerm);
+    const matchesStatus = statusFilter === 'ALL' || trade.status === statusFilter;
+    return matchesSearch && matchesStatus;
   });
 
-  // 정렬된 특허 목록
-  const sortedPatents = [...filteredPatents].sort((a, b) => {
+  // 정렬된 거래 목록
+  const sortedTrades = [...filteredTrades].sort((a, b) => {
     let aValue: string | number = '';
     let bValue: string | number = '';
     
@@ -110,18 +168,22 @@ export default function AdminPatentsPage() {
         aValue = a.price;
         bValue = b.price;
         break;
-      case 'favoriteCnt':
-        aValue = a.favoriteCnt;
-        bValue = b.favoriteCnt;
+      case 'id':
+        aValue = a.id;
+        bValue = b.id;
         break;
-      case 'title':
-        aValue = a.title.toLowerCase();
-        bValue = b.title.toLowerCase();
+      case 'postTitle':
+        aValue = a.postTitle || '';
+        bValue = b.postTitle || '';
+        break;
+      case 'postCategory':
+        aValue = a.postCategory || '';
+        bValue = b.postCategory || '';
         break;
       default:
         // fallback
-        aValue = a[sortBy as keyof Patent] as string;
-        bValue = b[sortBy as keyof Patent] as string;
+        aValue = a[sortBy as keyof TradeWithPostInfo] as string;
+        bValue = b[sortBy as keyof TradeWithPostInfo] as string;
         break;
     }
     
@@ -142,19 +204,19 @@ export default function AdminPatentsPage() {
       <section className="px-6 py-8">
         <div className="max-w-7xl mx-auto">
           <div className="flex items-center justify-between mb-8">
-            <h1 className="text-2xl font-bold text-white">관리자 - 특허 관리</h1>
+            <h1 className="text-2xl font-bold text-white">관리자 - 거래 내역 관리</h1>
           </div>
           
           {/* 관리자 네비게이션 */}
           <AdminNavigation user={user} />
 
-          {/* 특허 목록 카드 */}
+          {/* 거래 목록 카드 */}
           <div className="bg-white/95 backdrop-blur-sm rounded-2xl p-6 shadow-xl">
             <div className="flex items-center justify-between mb-6">
-              <h3 className="text-lg font-bold text-[#1a365d]">특허 목록</h3>
+              <h3 className="text-lg font-bold text-[#1a365d]">거래 내역 목록</h3>
               <div className="flex items-center gap-4">
                 <div className="text-sm text-gray-600">
-                  총 {sortedPatents.length}개의 특허 (전체 {patents.length}개)
+                  총 {sortedTrades.length}개의 거래 (전체 {trades.length}개)
                 </div>
                 <button
                   onClick={refetch}
@@ -172,29 +234,26 @@ export default function AdminPatentsPage() {
             {/* 검색 및 필터 */}
             <div className="mb-6 flex flex-col sm:flex-row gap-4">
               <div className="flex-1">
-                                 <input
-                   type="text"
-                   placeholder="제목으로 검색..."
-                   value={searchTerm}
-                   onChange={(e) => setSearchTerm(e.target.value)}
-                   className="w-full text-gray-900 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                 />
+                <input
+                  type="text"
+                  placeholder="거래 ID, 특허 제목, 카테고리, 거래금액으로 검색..."
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  className="w-full text-gray-900 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
               </div>
 
               <div className="sm:w-48">
                 <select
-                  value={categoryFilter}
-                  onChange={(e) => setCategoryFilter(e.target.value)}
+                  value={statusFilter}
+                  onChange={(e) => setStatusFilter(e.target.value)}
                   className="w-full text-gray-500 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
                 >
-                                     <option value="ALL">전체 카테고리</option>
-                   <option value="PRODUCT">물건발명</option>
-                   <option value="METHOD">방법발명</option>
-                   <option value="USE">용도발명</option>
-                   <option value="DESIGN">디자인권</option>
-                   <option value="TRADEMARK">상표권</option>
-                   <option value="COPYRIGHT">저작권</option>
-                   <option value="ETC">기타</option>
+                  <option value="ALL">전체 상태</option>
+                  <option value="REQUEST">거래 요청</option>
+                  <option value="ACCEPT">거래 수락</option>
+                  <option value="CANCELED">거래 취소</option>
+                  <option value="COMPLETED">거래 완료</option>
                 </select>
               </div>
             </div>
@@ -212,25 +271,22 @@ export default function AdminPatentsPage() {
             {isLoading ? (
               <div className="text-center py-12">
                 <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
-                <p className="text-gray-600 font-medium">특허 목록을 불러오는 중...</p>
+                <p className="text-gray-600 font-medium">거래 내역을 불러오는 중...</p>
                 <p className="text-sm text-gray-500 mt-2">잠시만 기다려주세요</p>
                 {error && (
                   <p className="text-sm text-red-500 mt-2">오류: {error}</p>
                 )}
               </div>
-            ) : sortedPatents.length === 0 ? (
+            ) : sortedTrades.length === 0 ? (
               <div className="text-center py-8">
                 <div className="text-gray-400 text-6xl mb-4">
-                  {patents.length === 0 ? '📄' : '🔍'}
+                  {trades.length === 0 ? '💰' : '🔍'}
                 </div>
                 <p className="text-gray-600">
-                  {patents.length === 0 ? '등록된 특허가 없습니다.' : '검색 결과가 없습니다.'}
+                  {trades.length === 0 ? '등록된 거래가 없습니다.' : '검색 결과가 없습니다.'}
                 </p>
                 <p className="text-sm text-gray-500 mt-2">
-                  {patents.length === 0 
-                    ? '백엔드에서 관리자 API가 구현되면 특허 목록이 표시됩니다.'
-                    : '다른 검색어나 필터를 시도해보세요.'
-                  }
+                  '다른 검색어나 필터를 시도해보세요.'
                 </p>
               </div>
             ) : (
@@ -242,24 +298,43 @@ export default function AdminPatentsPage() {
                       <th 
                         className="text-left py-3 px-4 font-medium text-gray-700 cursor-pointer hover:bg-gray-50"
                         onClick={() => {
-                          if (sortBy === 'title') {
+                          if (sortBy === 'postTitle') {
                             setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
                           } else {
-                            setSortBy('title');
-                            setSortOrder('asc');
+                            setSortBy('postTitle');
+                            setSortOrder('desc');
                           }
                         }}
                       >
                         <div className="flex items-center gap-1">
-                          제목
-                          {sortBy === 'title' && (
+                          특허 제목
+                          {sortBy === 'postTitle' && (
                             <span className="text-xs">
                               {sortOrder === 'asc' ? '↑' : '↓'}
                             </span>
                           )}
                         </div>
                       </th>
-                      <th className="text-left py-3 px-4 font-medium text-gray-700">카테고리</th>
+                      <th 
+                        className="text-left py-3 px-4 font-medium text-gray-700 cursor-pointer hover:bg-gray-50"
+                        onClick={() => {
+                          if (sortBy === 'postCategory') {
+                            setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
+                          } else {
+                            setSortBy('postCategory');
+                            setSortOrder('desc');
+                          }
+                        }}
+                      >
+                        <div className="flex items-center gap-1">
+                          카테고리
+                          {sortBy === 'postCategory' && (
+                            <span className="text-xs">
+                              {sortOrder === 'asc' ? '↑' : '↓'}
+                            </span>
+                          )}
+                        </div>
+                      </th>
                       <th 
                         className="text-left py-3 px-4 font-medium text-gray-700 cursor-pointer hover:bg-gray-50"
                         onClick={() => {
@@ -272,7 +347,7 @@ export default function AdminPatentsPage() {
                         }}
                       >
                         <div className="flex items-center gap-1">
-                          가격
+                          거래금액
                           {sortBy === 'price' && (
                             <span className="text-xs">
                               {sortOrder === 'asc' ? '↑' : '↓'}
@@ -281,26 +356,6 @@ export default function AdminPatentsPage() {
                         </div>
                       </th>
                       <th className="text-left py-3 px-4 font-medium text-gray-700">상태</th>
-                      <th 
-                        className="text-left py-3 px-4 font-medium text-gray-700 cursor-pointer hover:bg-gray-50"
-                        onClick={() => {
-                          if (sortBy === 'favoriteCnt') {
-                            setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
-                          } else {
-                            setSortBy('favoriteCnt');
-                            setSortOrder('desc');
-                          }
-                        }}
-                      >
-                        <div className="flex items-center gap-1">
-                          좋아요
-                          {sortBy === 'favoriteCnt' && (
-                            <span className="text-xs">
-                              {sortOrder === 'asc' ? '↑' : '↓'}
-                            </span>
-                          )}
-                        </div>
-                      </th>
                       <th 
                         className="text-left py-3 px-4 font-medium text-gray-700 cursor-pointer hover:bg-gray-50"
                         onClick={() => {
@@ -313,7 +368,7 @@ export default function AdminPatentsPage() {
                         }}
                       >
                         <div className="flex items-center gap-1">
-                          등록일
+                          거래일시
                           {sortBy === 'createdAt' && (
                             <span className="text-xs">
                               {sortOrder === 'asc' ? '↑' : '↓'}
@@ -325,55 +380,48 @@ export default function AdminPatentsPage() {
                     </tr>
                   </thead>
                   <tbody>
-                    {sortedPatents.map((patent, index) => (
-                      <tr key={patent.id} className="border-b border-gray-100 hover:bg-blue-50 cursor-pointer transition-colors duration-200" onClick={() => handlePatentClick(patent.id)}>
+                    {sortedTrades.map((trade, index) => (
+                      <tr key={trade.id} className="border-b border-gray-100 hover:bg-blue-50 cursor-pointer transition-colors duration-200" onClick={() => handleTradeClick(trade.id)}>
                         <td className="py-3 px-4 text-gray-500">{index + 1}</td>
-                        <td className="py-3 px-4 text-gray-900">{patent.title}</td>
-                                                 <td className="py-3 px-4">
-                           <span className={`px-2 py-1 rounded-full text-xs ${
-                             patent.category === 'PRODUCT' 
-                               ? 'bg-blue-100 text-blue-800' 
-                               : patent.category === 'METHOD'
-                               ? 'bg-green-100 text-green-800'
-                               : patent.category === 'USE'
-                               ? 'bg-purple-100 text-purple-800'
-                               : patent.category === 'DESIGN'
-                               ? 'bg-orange-100 text-orange-800'
-                               : patent.category === 'TRADEMARK'
-                               ? 'bg-red-100 text-red-800'
-                               : patent.category === 'COPYRIGHT'
-                               ? 'bg-indigo-100 text-indigo-800'
-                               : patent.category === 'ETC'
-                               ? 'bg-gray-100 text-gray-800'
-                               : 'bg-gray-100 text-gray-800'
-                           }`}>
-                             {getCategoryLabel(patent.category)}
-                           </span>
-                         </td>
-                        <td className="py-3 px-4 text-gray-900">{patent.price.toLocaleString()}원</td>
+                        <td className="py-3 px-4 text-gray-900">{trade.postTitle || '제목 없음'}</td>
                         <td className="py-3 px-4">
-                          <span className={`px-2 py-1 rounded-full text-xs ${
-                            patent.status === 'SALE' 
-                              ? 'bg-green-100 text-green-800' 
-                              : patent.status === 'SOLD_OUT'
-                              ? 'bg-red-100 text-red-800'
-                              : patent.status === 'SUSPENDED'
-                              ? 'bg-yellow-100 text-yellow-800'
-                              : 'bg-gray-100 text-gray-800'
-                          }`}>
-                            {getStatusLabel(patent.status)}
+                          <span
+                            className={`px-2 py-1 rounded-full text-xs ${
+                              trade.postCategory === '물건발명'
+                                ? 'bg-blue-100 text-blue-800'
+                                : trade.postCategory === '방법발명'
+                                ? 'bg-green-100 text-green-800'
+                                : trade.postCategory === '용도발명'
+                                ? 'bg-purple-100 text-purple-800'
+                                : trade.postCategory === '디자인권'
+                                ? 'bg-orange-100 text-orange-800'
+                                : trade.postCategory === '상표권'
+                                ? 'bg-red-100 text-red-800'
+                                : trade.postCategory === '저작권'
+                                ? 'bg-indigo-100 text-indigo-800'
+                                : trade.postCategory === '기타'
+                                ? 'bg-gray-100 text-gray-800'
+                                : 'bg-gray-100 text-gray-800' // 기본 회색
+                            }`}
+                          >
+                            {trade.postCategory || '카테고리 없음'}
                           </span>
                         </td>
-                        <td className="py-3 px-4 text-gray-900">{patent.favoriteCnt}</td>
+                        <td className="py-3 px-4 text-gray-900">{trade.price.toLocaleString()}원</td>
+                        <td className="py-3 px-4">
+                          <span className={`px-2 py-1 rounded-full text-xs ${getStatusColor(trade.status)}`}>
+                            {getStatusLabel(trade.status)}
+                          </span>
+                        </td>
                         <td className="py-3 px-4 text-gray-500">
-                          {new Date(patent.createdAt).toLocaleDateString()}
+                          {new Date(trade.createdAt).toLocaleDateString()} {new Date(trade.createdAt).toLocaleTimeString()}
                         </td>
                         <td className="py-3 px-4 text-center">
                           <div className="flex justify-center gap-2">
                             <button 
                               onClick={(e) => {
                                 e.stopPropagation();
-                                handlePatentClick(patent.id);
+                                handleTradeClick(trade.id);
                               }}
                               className="text-blue-600 cursor-pointer hover:text-blue-700 text-xs font-medium bg-blue-50 hover:bg-blue-100 px-2 py-1 rounded transition-colors"
                             >
@@ -391,15 +439,15 @@ export default function AdminPatentsPage() {
         </div>
       </section>
 
-      {/* 특허 상세 정보 모달 */}
-      {selectedPatentId && (
-        <PatentDetailModal
+      {/* 거래 상세 정보 모달 */}
+      {selectedTradeId && (
+        <TradeDetailModal
           isOpen={isModalOpen}
           onClose={handleModalClose}
-          patentId={selectedPatentId}
-          onPatentUpdated={handlePatentUpdated}
+          tradeId={selectedTradeId}
+          onTradeUpdated={handleTradeUpdated}
         />
       )}
     </div>
   );
-} 
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -391,7 +391,7 @@ export default function LoginPage() {
                        <button
                          type="button"
                          onClick={handleBackToLogin}
-                         className="w-full bg-purple-600 hover:bg-purple-700 text-white py-3 rounded-lg transition-colors font-medium"
+                         className="w-full bg-purple-600 hover:bg-purple-700 text-white py-3 rounded-lg transition-colors font-medium cursor-pointer"
                        >
                          로그인 페이지로 돌아가기
                        </button>
@@ -463,29 +463,73 @@ export default function LoginPage() {
               </div>
             )}
             
-                          {!showPasswordReset && (
-                <div className="mt-6">
-                  <div className="relative">
-                    <div className="absolute inset-0 flex items-center">
-                      <div className="w-full border-t border-gray-300" />
-                    </div>
-                    <div className="relative flex justify-center text-sm">
-                      <span className="px-2 bg-white text-gray-500">또는</span>
-                    </div>
+            {!showPasswordReset && (
+              <div className="mt-6">
+                <div className="relative">
+                  <div className="absolute inset-0 flex items-center">
+                    <div className="w-full border-t border-gray-300" />
                   </div>
-                  
-                  <div className="mt-6 grid grid-cols-2 gap-3">
-                    <button className="w-full inline-flex justify-center py-2 px-4 border border-gray-300 rounded-lg shadow-sm bg-white text-sm font-medium text-gray-500 hover:bg-gray-50">
-                      <span className="text-lg mr-2">📧</span>
-                      이메일
-                    </button>
-                    <button className="w-full inline-flex justify-center py-2 px-4 border border-gray-300 rounded-lg shadow-sm bg-white text-sm font-medium text-gray-500 hover:bg-gray-50">
-                      <span className="text-lg mr-2">📱</span>
-                      카카오
-                    </button>
+                  <div className="relative flex justify-center text-sm">
+                    <span className="px-2 bg-white text-gray-500">또는</span>
                   </div>
                 </div>
-              )}
+                
+                <div className="mt-6 grid grid-cols-1 gap-3">
+                  {/* Google - simple white button with Google icon */}
+                  <button
+                    type="button"
+                    className="btGoogle w-full h-12 rounded-lg shadow-sm border border-gray-300 bg-white text-black hover:bg-gray-50"
+                    onClick={() => { window.location.href = "/oauth2/authorization/google"; }}
+                    aria-label="Sign in with Google"
+                  >
+                    <span className="tpaLoginInnerWrap flex items-center justify-center gap-2 py-3 px-4 cursor-pointer">
+                      <span className="inline-block" aria-hidden="true" style={{ width: '18px', height: '18px' }}>
+                        <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+                          <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"></path>
+                          <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"></path>
+                          <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"></path>
+                          <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"></path>
+                          <path fill="none" d="M0 0h48v48H0z"></path>
+                        </svg>
+                      </span>
+                      <span className="tpaLoginTxt text-sm font-medium">Google 계정으로 로그인</span>
+                    </span>
+                  </button>
+
+                  {/* Kakao official-like */}
+                  <button
+                    type="button"
+                    className="btKakao w-full h-12 rounded-lg shadow-sm"
+                    onClick={() => { window.location.href = "/oauth2/authorization/kakao"; }}
+                    style={{ backgroundColor: '#FEE500', color: '#191600' }}
+                    aria-label="카카오 로그인"
+                  >
+                    <span className="tpaLoginInnerWrap flex items-center justify-center gap-2 py-3 px-4 cursor-pointer">
+                      <svg width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M12 4C7.582 4 4 6.807 4 10.27c0 2.116 1.407 3.96 3.527 4.99-.094.35-.336 1.269-.388 1.467-.058.224.081.226.176.164.076-.05 1.199-.82 1.678-1.149.509.076 1.04.116 1.592.116 4.418 0 8-2.807 8-6.27C18.585 6.807 15.003 4 12 4z" fill="#000000"/>
+                      </svg>
+                      <span className="tpaLoginTxt text-sm font-medium">Kakao 계정으로 로그인</span>
+                    </span>
+                  </button>
+
+                  {/* Naver official-like */}
+                  <button
+                    type="button"
+                    className="btNaver w-full h-12 rounded-lg shadow-sm"
+                    onClick={() => { window.location.href = "/oauth2/authorization/naver"; }}
+                    style={{ backgroundColor: '#03C75A', color: '#FFFFFF' }}
+                    aria-label="네이버 로그인"
+                  >
+                    <span className="tpaLoginInnerWrap flex items-center justify-center gap-2 py-3 px-4 cursor-pointer">
+                      <svg width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M7 6h3.9l2.9 4.5V6H17v12h-3.9L10.2 13.5V18H7V6z" fill="#FFFFFF"/>
+                      </svg>
+                      <span className="tpaLoginTxt text-sm font-medium">Naver 계정으로 로그인</span>
+                    </span>
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
         </div>
       </section>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -182,7 +182,7 @@ export default function RegisterPage() {
                   name="agree"
                   checked={formData.agree}
                   onChange={handleInputChange}
-                  className="rounded border-gray-300 text-purple-600 focus:ring-purple-500"
+                  className="rounded border-gray-300 text-purple-600 focus:ring-purple-500 cursor-pointer"
                   required
                 />
                 <label htmlFor="agree" className="ml-2 text-sm text-gray-600">
@@ -194,7 +194,7 @@ export default function RegisterPage() {
               <button
                 type="submit"
                 disabled={isLoading}
-                className="w-full bg-purple-600 hover:bg-purple-700 disabled:bg-purple-400 text-white py-3 rounded-lg transition-colors font-medium"
+                className="w-full bg-purple-600 hover:bg-purple-700 disabled:bg-purple-400 text-white py-3 rounded-lg transition-colors font-medium cursor-pointer"
               >
                 {isLoading ? "처리 중..." : "회원가입"}
               </button>
@@ -219,14 +219,58 @@ export default function RegisterPage() {
                 </div>
               </div>
               
-              <div className="mt-6 grid grid-cols-2 gap-3">
-                <button className="w-full inline-flex justify-center py-2 px-4 border border-gray-300 rounded-lg shadow-sm bg-white text-sm font-medium text-gray-500 hover:bg-gray-50">
-                  <span className="text-lg mr-2">📧</span>
-                  이메일
+              <div className="mt-6 grid grid-cols-1 gap-3">
+                {/* Google - simple white button with Google icon */}
+                <button
+                  type="button"
+                  className="btGoogle w-full h-12 rounded-lg shadow-sm border border-gray-300 bg-white text-black hover:bg-gray-50"
+                  onClick={() => { window.location.href = "/oauth2/authorization/google"; }}
+                  aria-label="Sign in with Google"
+                >
+                  <span className="tpaLoginInnerWrap flex items-center justify-center gap-2 py-3 px-4 cursor-pointer">
+                    <span className="inline-block" aria-hidden="true" style={{ width: '18px', height: '18px' }}>
+                      <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+                        <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"></path>
+                        <path fill="#4285F4" d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"></path>
+                        <path fill="#FBBC05" d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76--4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"></path>
+                        <path fill="#34A853" d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"></path>
+                        <path fill="none" d="M0 0h48v48H0z"></path>
+                      </svg>
+                    </span>
+                    <span className="tpaLoginTxt text-sm font-medium">Google 계정으로 로그인</span>
+                  </span>
                 </button>
-                <button className="w-full inline-flex justify-center py-2 px-4 border border-gray-300 rounded-lg shadow-sm bg-white text-sm font-medium text-gray-500 hover:bg-gray-50">
-                  <span className="text-lg mr-2">📱</span>
-                  카카오
+
+                {/* Kakao */}
+                <button
+                  type="button"
+                  className="btKakao w-full h-12 rounded-lg shadow-sm"
+                  onClick={() => { window.location.href = "/oauth2/authorization/kakao"; }}
+                  style={{ backgroundColor: '#FEE500', color: '#191600' }}
+                  aria-label="카카오 로그인"
+                >
+                  <span className="tpaLoginInnerWrap flex items-center justify-center gap-2 py-3 px-4 cursor-pointer">
+                    <svg width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M12 4C7.582 4 4 6.807 4 10.27c0 2.116 1.407 3.96 3.527 4.99-.094.35-.336 1.269-.388 1.467-.058.224.081.226.176.164.076-.05 1.199-.82 1.678-1.149.509.076 1.04.116 1.592.116 4.418 0 8-2.807 8-6.27C18.585 6.807 15.003 4 12 4z" fill="#000000"/>
+                    </svg>
+                    <span className="tpaLoginTxt text-sm font-medium">Kakao 계정으로 로그인</span>
+                  </span>
+                </button>
+
+                {/* Naver */}
+                <button
+                  type="button"
+                  className="btNaver w-full h-12 rounded-lg shadow-sm"
+                  onClick={() => { window.location.href = "/oauth2/authorization/naver"; }}
+                  style={{ backgroundColor: '#03C75A', color: '#FFFFFF' }}
+                  aria-label="네이버 로그인"
+                >
+                  <span className="tpaLoginInnerWrap flex items-center justify-center gap-2 py-3 px-4 cursor-pointer">
+                    <svg width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                      <path d="M7 6h3.9l2.9 4.5V6H17v12h-3.9L10.2 13.5V18H7V6z" fill="#FFFFFF"/>
+                    </svg>
+                    <span className="tpaLoginTxt text-sm font-medium">Naver 계정으로 로그인</span>
+                  </span>
                 </button>
               </div>
             </div>

--- a/src/app/register/success/page.tsx
+++ b/src/app/register/success/page.tsx
@@ -58,14 +58,14 @@ export default function RegisterSuccessPage() {
             <div className="space-y-4">
               <button
                 onClick={handleLoginClick}
-                className="w-full bg-purple-600 hover:bg-purple-700 text-white py-3 rounded-lg transition-colors font-medium"
+                className="w-full bg-purple-600 hover:bg-purple-700 text-white py-3 rounded-lg transition-colors font-medium cursor-pointer"
               >
                 로그인하기
               </button>
               
               <button
                 onClick={handleHomeClick}
-                className="w-full bg-gray-100 hover:bg-gray-200 text-gray-700 py-3 rounded-lg transition-colors font-medium"
+                className="w-full bg-gray-200 hover:bg-gray-300 text-gray-700 py-3 rounded-lg transition-colors font-medium cursor-pointer"
               >
                 홈으로 돌아가기
               </button>

--- a/src/components/AdminNavigation.tsx
+++ b/src/components/AdminNavigation.tsx
@@ -17,6 +17,7 @@ export default function AdminNavigation({ user }: AdminNavigationProps) {
   const navItems = [
     { href: '/admin/members', label: '회원 관리', icon: '👥' },
     { href: '/admin/patents', label: '특허 관리', icon: '📋' },
+    { href: '/admin/trades', label: '거래 내역', icon: '💰' },
   ];
 
   return (

--- a/src/components/admin/MemberDetailModal.tsx
+++ b/src/components/admin/MemberDetailModal.tsx
@@ -112,32 +112,7 @@ export default function MemberDetailModal({
     }
   };
 
-  // 회원 탈퇴 처리
-  const handleDeleteMember = async () => {
-    if (!memberId) return;
-    
-    if (!confirm('정말로 이 회원을 탈퇴시키시겠습니까? 이 작업은 되돌릴 수 없습니다.')) {
-      return;
-    }
-    
-    setIsLoading(true);
-    setError(null);
-    setSuccessMessage(null);
-    
-    try {
-      await adminAPI.deleteMemberByAdmin(memberId);
-      setSuccessMessage('회원이 성공적으로 탈퇴되었습니다.');
-      onMemberUpdated();
-      setTimeout(() => {
-        onClose();
-      }, 1500);
-    } catch (err: unknown) {
-      const error = err as ApiError;
-      setError(error.response?.data?.message || '회원 탈퇴에 실패했습니다.');
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  // 회원 탈퇴 기능 제거됨
 
   useEffect(() => {
     if (isOpen && memberId) {
@@ -428,18 +403,6 @@ export default function MemberDetailModal({
                          닫기
                        </button>
                      </div>
-                     <button
-                       onClick={handleDeleteMember}
-                       disabled={isLoading || member.status === 'DELETED'}
-                       className={`px-4 py-2 rounded-md ${
-                         member.status === 'DELETED'
-                           ? 'bg-gray-400 text-gray-600 cursor-not-allowed'
-                           : 'bg-red-600 text-white cursor-pointer hover:bg-red-700'
-                       } disabled:opacity-50`}
-                     >
-                       {isLoading ? '탈퇴 중...' : 
-                        member.status === 'DELETED' ? '이미 탈퇴됨' : '회원탈퇴'}
-                     </button>
                    </div>
                 </div>
               )}

--- a/src/components/admin/TradeDetailModal.tsx
+++ b/src/components/admin/TradeDetailModal.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { adminAPI } from '@/utils/apiClient';
+
+interface Trade {
+  id: number;
+  postId: number;
+  postTitle: string;
+  postCategory: string;
+  price: number;
+  status: string;
+  createdAt: string;
+  sellerEmail: string;
+  buyerEmail: string;
+}
+
+interface ApiError {
+  response?: {
+    data?: {
+      message?: string;
+    };
+  };
+}
+
+// 거래 상태를 한글로 변환하는 함수
+const getStatusLabel = (status: string): string => {
+  switch (status) {
+    case 'REQUEST':
+      return '거래 요청';
+    case 'ACCEPT':
+      return '거래 수락';
+    case 'CANCELED':
+      return '거래 취소';
+    case 'COMPLETED':
+      return '거래 완료';
+    default:
+      return status;
+  }
+};
+
+// 거래 상태에 따른 색상 클래스
+const getStatusColor = (status: string): string => {
+  switch (status) {
+    case 'REQUEST':
+      return 'bg-yellow-100 text-yellow-800';
+    case 'ACCEPT':
+      return 'bg-blue-100 text-blue-800';
+    case 'CANCELED':
+      return 'bg-red-100 text-red-800';
+    case 'COMPLETED':
+      return 'bg-green-100 text-green-800';
+    default:
+      return 'bg-gray-100 text-gray-800';
+  }
+};
+
+interface TradeDetailModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  tradeId: number;
+  onTradeUpdated: () => void;
+}
+
+export default function TradeDetailModal({ 
+  isOpen, 
+  onClose, 
+  tradeId, 
+  onTradeUpdated 
+}: TradeDetailModalProps) {
+  const [trade, setTrade] = useState<Trade | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 거래 상세 정보 조회
+  const fetchTradeDetail = useCallback(async () => {
+    if (!tradeId) return;
+    
+    setIsLoading(true);
+    setError(null);
+    
+    try {
+      const response = await adminAPI.getTradeDetail(tradeId);
+      const tradeData = response.data;
+      setTrade(tradeData);
+    } catch (err) {
+      console.error('거래 상세 정보 조회 실패:', err);
+      const apiError = err as ApiError;
+      setError(apiError.response?.data?.message || '거래 상세 정보를 불러오는데 실패했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [tradeId]);
+
+  // 모달이 열릴 때마다 거래 정보 조회
+  useEffect(() => {
+    if (isOpen && tradeId) {
+      fetchTradeDetail();
+    }
+  }, [isOpen, tradeId, fetchTradeDetail]);
+
+  // 모달 닫기
+  const handleClose = () => {
+    setTrade(null);
+    setError(null);
+    onClose();
+  };
+
+  // 모달 외부 클릭 시 닫기
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      handleClose();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center z-50">
+      <div className="bg-white rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+        {/* 헤더 */}
+        <div className="flex items-center justify-between p-6 border-b border-gray-200">
+          <h2 className="text-xl font-bold text-gray-900">거래 상세 정보</h2>
+          <button
+            onClick={handleClose}
+            className="text-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* 내용 */}
+        <div className="p-6">
+          {isLoading ? (
+            <div className="text-center py-8">
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+              <p className="text-gray-600">거래 정보를 불러오는 중...</p>
+            </div>
+          ) : error ? (
+            <div className="text-center py-8">
+              <div className="text-red-500 text-6xl mb-4">⚠️</div>
+              <p className="text-red-600 font-medium mb-2">오류가 발생했습니다</p>
+              <p className="text-gray-600 text-sm">{error}</p>
+              <button
+                onClick={fetchTradeDetail}
+                className="mt-4 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+              >
+                다시 시도
+              </button>
+            </div>
+          ) : trade ? (
+            <div className="space-y-6">
+              {/* 거래 기본 정보 */}
+              <div className="bg-gray-50 rounded-lg p-4">
+                <h3 className="text-lg font-semibold text-gray-900 mb-4">거래 정보</h3>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-600 mb-1">거래 ID</label>
+                    <p className="text-gray-900 font-medium">{trade.id}</p>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-600 mb-1">거래 상태</label>
+                    <span className={`px-3 py-1 rounded-full text-sm font-medium ${getStatusColor(trade.status)}`}>
+                      {getStatusLabel(trade.status)}
+                    </span>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-600 mb-1">거래 금액</label>
+                    <p className="text-gray-900 font-semibold text-lg">{trade.price.toLocaleString()}원</p>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-600 mb-1">거래일시</label>
+                    <p className="text-gray-900">
+                      {new Date(trade.createdAt).toLocaleDateString()} {new Date(trade.createdAt).toLocaleTimeString()}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* 게시글 정보 */}
+              <div className="bg-gray-50 rounded-lg p-4">
+                <h3 className="text-lg font-semibold text-gray-900 mb-4">게시글 정보</h3>
+                <div className="space-y-3">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-600 mb-1">게시글 ID</label>
+                    <p className="text-gray-900 font-medium">{trade.postId}</p>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-600 mb-1">제목</label>
+                    <p className="text-gray-900 font-medium">{trade.postTitle}</p>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-600 mb-1">카테고리</label>
+                    <p className="text-gray-900">{trade.postCategory}</p>
+                  </div>
+                </div>
+              </div>
+
+              {/* 거래자 정보 */}
+              <div className="bg-gray-50 rounded-lg p-4">
+                <h3 className="text-lg font-semibold text-gray-900 mb-4">거래자 정보</h3>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-600 mb-1">판매자 이메일</label>
+                    <p className="text-gray-900 font-medium">{trade.sellerEmail}</p>
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-600 mb-1">구매자 이메일</label>
+                    <p className="text-gray-900 font-medium">{trade.buyerEmail}</p>
+                  </div>
+                </div>
+              </div>
+
+            </div>
+          ) : null}
+        </div>
+
+        {/* 푸터 */}
+        <div className="flex justify-end p-6 border-t border-gray-200">
+          <button
+            onClick={handleClose}
+            className="px-6 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors cursor-pointer"
+          >
+            닫기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -423,7 +423,14 @@ export const adminAPI = {
   },
 
   // 모든 거래 조회 (관리자 전용)
-  getAllTrades: async (): Promise<{
+    getAllTrades: async (params?: {
+    page?: number;
+    size?: number;
+    status?: string;
+    sellerEmail?: string;
+    buyerEmail?: string;
+    postId?: number;
+  }): Promise<{
     resultCode: string;
     msg: string;
     data: {
@@ -439,9 +446,9 @@ export const adminAPI = {
       totalElements: number;
       totalPages: number;
       pageable: Pageable;
-    }
+    };
   }> => {
-    const response = await apiClient.get('/api/admin/trades');
+    const response = await apiClient.get('/api/admin/trades', { params });
     return response.data;
   },
 

--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -421,6 +421,49 @@ export const adminAPI = {
   deletePatentByAdmin: async (patentId: number): Promise<void> => {
     await apiClient.delete(`/api/admin/patents/${patentId}`);
   },
+
+  // 모든 거래 조회 (관리자 전용)
+  getAllTrades: async (): Promise<{
+    resultCode: string;
+    msg: string;
+    data: {
+      content: Array<{
+        id: number;
+        postId: number;
+        sellerId: number;
+        buyerId: number;
+        price: number;
+        status: string;
+        createdAt: string;
+      }>;
+      totalElements: number;
+      totalPages: number;
+      pageable: Pageable;
+    }
+  }> => {
+    const response = await apiClient.get('/api/admin/trades');
+    return response.data;
+  },
+
+  // 거래 상세 정보 조회 (관리자 전용)
+  getTradeDetail: async (tradeId: number): Promise<{
+    resultCode: string;
+    msg: string;
+    data: {
+      id: number;
+      postId: number;
+      postTitle: string;
+      postCategory: string;
+      price: number;
+      status: string;
+      createdAt: string;
+      sellerEmail: string;
+      buyerEmail: string;
+    }
+  }> => {
+    const response = await apiClient.get(`/api/admin/trades/${tradeId}`);
+    return response.data;
+  },
 };
 
 export default apiClient;


### PR DESCRIPTION
관리자 페이지 거래 내역 관리 페이지 추가

소셜로그인 UI만 추가(ㅎ..ㅎ)

불필요한 버튼들 삭제 및 개선작업 완
(로그인, 회원가입, 관리자 페이지 한정)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 관리자 거래 내역 페이지 추가: 검색·필터·정렬, 새로고침, 행 클릭/버튼으로 상세 모달 열기.
  - 거래 상세 모달 추가: 거래·게시글·거래자 정보, 상태·가격 표시, 로딩·에러 처리.
  - 관리자 내비게이션에 “거래 내역” 메뉴 추가.
  - 로그인/회원가입 화면에 Google·Kakao·Naver 소셜 로그인 버튼 도입.

- 변경
  - 회원 상세 모달에서 회원 탈퇴 기능 제거.

- 스타일
  - 로그인/회원가입/가입완료 버튼·체크박스에 커서 표시 추가 및 버튼 색상·레이아웃 개선.
  - 관리자 특허 목록 제목의 굵기 제거.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->